### PR TITLE
[ASL-408] upgrade gql  query - gasPrice by switching chain

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qubic-js/core",
-  "version": "0.1.13",
+  "version": "0.1.12",
   "description": "",
   "license": "Apache License 2.0",
   "source": "./src/index.ts",


### PR DESCRIPTION
1. the ability to query gasPrice by chainId
2. bump @qubic-js/core to 0.1.13