### PR TITLE
removed completed 3d payment

### DIFF
--- a/packages/core/src/web3/Provider.ts
+++ b/packages/core/src/web3/Provider.ts
@@ -176,11 +176,6 @@ export class Provider implements ProviderInterface {
           return;
         }
 
-        // workaround: should be removed when persist WalletCoordinator requests ready
-        if (action === 'complete3dPayment') {
-          window.removeEventListener('message', listener);
-          return;
-        }
         if (action === 'hideIframe') {
           reject(ethErrors.provider.userRejectedRequest('Qubic Message Signature: User denied message signature.'));
           window.removeEventListener('message', listener);


### PR DESCRIPTION
有了tappay 改成是 popup 之後，就不用之前 workaround 的方式去聽 complete3dpayment 了，之前是因為 iframe 整個會被刷新狀態會丟失。
需要 complete3dPayment 讓 sdk 知道信用卡流程結束，把監聽事件都取消掉。

這也造成 complete3dpayment 先到之後，把  sdk on message listener 砍掉，所以接下來的 approve 在 sdk 就沒 handler 了。