### PR TITLE
[ASL-1164] make a resolver for none login signal action

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -347,11 +347,11 @@ const App = React.memo(() => {
         value: '0x9184e72a',
         data: '0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675',
       },
-      (error, gas) => {
+      (_, gas) => {
         console.log(`gas=${gas}`);
       },
     );
-  }, [Boolean(web3)]);
+  }, [web3?.eth]);
 
   const handleEstimateCosts = useCallback(async () => {
     const amis = qubicConnector.getClient();
@@ -372,8 +372,8 @@ const App = React.memo(() => {
     };
 
     web3?.eth
-      .sendTransaction(tx, (error, hash) => {
-        if (error) console.error(error);
+      .sendTransaction(tx, (sendError, hash) => {
+        if (sendError) console.error(sendError);
         else console.log('tx hash:', hash);
       })
       .once('transactionHash', hash => {
@@ -405,8 +405,8 @@ const App = React.memo(() => {
     };
 
     web3?.eth
-      .sendTransaction(tx, (error, hash) => {
-        if (error) console.error(error);
+      .sendTransaction(tx, (getERCError, hash) => {
+        if (getERCError) console.error(getERCError);
         else console.log('tx hash:', hash);
       })
       .once('transactionHash', hash => {
@@ -444,8 +444,8 @@ const App = React.memo(() => {
         value: 0,
         gas: 100000,
       })
-      .on('error', (error: Error): void => {
-        console.error(error);
+      .on('error', (contractError: Error): void => {
+        console.error(contractError);
       })
       .once('transactionHash', (hash: string) => {
         console.log(hash);
@@ -470,8 +470,8 @@ const App = React.memo(() => {
         value: 0,
         gas: 100000,
       })
-      .on('error', (error: Error): void => {
-        console.error(error);
+      .on('error', (approveError: Error): void => {
+        console.error(approveError);
       })
       .once('transactionHash', (hash: string) => {
         console.log(hash);
@@ -491,8 +491,8 @@ const App = React.memo(() => {
         // The signer should always be the proxy owner
         const signerAddress = web3?.eth.accounts.recover(data, signature);
         console.log(`signerAddress=${signerAddress}`);
-      } catch (error) {
-        const { code, message, stack } = error as any;
+      } catch (err) {
+        const { code, message, stack } = err as any;
         console.error({
           code,
           message,
@@ -572,9 +572,9 @@ const App = React.memo(() => {
             method: 'eth_signTypedData_v3',
             params: [from, JSON.stringify(msgParams)],
           },
-          (error, response) => {
-            if (error) {
-              reject(error);
+          (ethSignTypedDataError, response) => {
+            if (ethSignTypedDataError) {
+              reject(ethSignTypedDataError);
             } else {
               resolve(response?.result);
             }
@@ -654,9 +654,9 @@ const App = React.memo(() => {
             method: 'eth_signTypedData_v4',
             params: [from, JSON.stringify(msgParams)],
           },
-          (error, response) => {
-            if (error) {
-              reject(error);
+          (ethSignTypedDataV4Error, response) => {
+            if (ethSignTypedDataV4Error) {
+              reject(ethSignTypedDataV4Error);
             } else {
               resolve(response?.result);
             }
@@ -696,9 +696,9 @@ const App = React.memo(() => {
             },
           ],
         },
-        (error, response) => {
-          if (error) {
-            console.error(error);
+        (bindOperateEthereumChainError, response) => {
+          if (bindOperateEthereumChainError) {
+            console.error(bindOperateEthereumChainError);
           } else {
             console.log(response?.result);
           }

--- a/packages/browser/src/store.ts
+++ b/packages/browser/src/store.ts
@@ -1,6 +1,7 @@
 import { Store, Address } from '@qubic-js/core';
 
 const QUBIC_CURRENT_ADDRESS = 'QUBIC_CURRENT_ADDRESS';
+const QUBIC_CURRENT_NETWORK = 'QUBIC_CURRENT_NETWORK';
 const QUBIC_ADDRESSES = 'QUBIC_ADDRESSES';
 
 export class BrowserStore implements Store {
@@ -22,6 +23,14 @@ export class BrowserStore implements Store {
 
   public setCurrentAddress = (address: string | null | undefined): void => {
     this.updateItem(QUBIC_CURRENT_ADDRESS, address);
+  };
+
+  public getCurrentNetwork = (): string | null => {
+    return this.getItem(QUBIC_CURRENT_NETWORK);
+  };
+
+  public setCurrentNetwork = (network: string | null | undefined): void => {
+    this.updateItem(QUBIC_CURRENT_NETWORK, network);
   };
 
   public getAddresses = (): Address[] | null => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -3,6 +3,8 @@ import { Address } from './types';
 export interface Store {
   getCurrentAddress: () => string | null;
   setCurrentAddress: (address: string | null | undefined) => void;
+  getCurrentNetwork: () => string | null;
+  setCurrentNetwork: (network: string | null | undefined) => void;
   getAddresses: () => Address[] | null;
   setAddresses: (addresses: Address[] | null | undefined) => void;
   clear: () => void;

--- a/packages/core/src/web3/Provider.ts
+++ b/packages/core/src/web3/Provider.ts
@@ -132,6 +132,14 @@ export class Provider implements ProviderInterface {
           end(e);
         }
         break;
+      case 'eth_chainId':
+        try {
+          const network = this.network();
+          end(null, network);
+        } catch (e) {
+          end(e);
+        }
+        break;
       case 'eth_blockNumber':
         // fixed issue https://github.com/MetaMask/eth-block-tracker/pull/42
         // web-provider-engine has dependency eth-block-tracer@^4.4.2
@@ -200,5 +208,11 @@ export class Provider implements ProviderInterface {
     const address = AMIS.sharedStore.getCurrentAddress();
     if (!address) return [];
     return [address];
+  };
+
+  public network = (): string => {
+    const network = AMIS.sharedStore.getCurrentNetwork();
+    if (!network) throw new Error('No Network');
+    return network;
   };
 }


### PR DESCRIPTION
使用 iframe 做 login & sign 的時候，如果前端 deactivate 之後，Qubic Wallet 會直接進入 welcome screen。
原因是Qubic 在成功login 之後會無法成功再次執行 activate resolver，應該是多鏈實作衍生的問題。
跟steven 討論之後，先行改為使用兩個 resolver 的方式，第一次 login 會使用 message event listener，之後則使用 provider 本身的 rpc 做回傳。在重新 refactor  Qubic 狀態之前先使用這個 workaround 解決 status 無法 sync. issue。