### PR TITLE
Fix arbitrumSepolia chainId and color

### DIFF
--- a/packages/core/src/constants/network.ts
+++ b/packages/core/src/constants/network.ts
@@ -105,7 +105,7 @@ export const NETWORK_INFO: Record<Network, NetworkInfo> = {
     chainId: Network.ARBITRUM,
     ensAddress: '0x0000000000000000000000000000000000000000',
     explorerUrl: 'https://arbiscan.io',
-    color: '#17202c',
+    color: '#1b4add',
     nativeToken: ETHEREUM_NATIVE_TOKEN, // Using ETH as native token
     networkType: 'arbitrum',
     rpc: {
@@ -117,7 +117,7 @@ export const NETWORK_INFO: Record<Network, NetworkInfo> = {
     chainId: Network.ARBITRUM_SEPOLIA,
     ensAddress: '0x0000000000000000000000000000000000000000',
     explorerUrl: 'https://sepolia.arbiscan.io',
-    color: '#17202c',
+    color: '#1b4add',
     nativeToken: ETHEREUM_NATIVE_TOKEN, // Using ETH as native token
     networkType: 'arbitrum',
     rpc: {

--- a/packages/core/src/types/chain.ts
+++ b/packages/core/src/types/chain.ts
@@ -7,7 +7,7 @@ export enum Network {
   BSC = 56,
   BSC_TESTNET = 97,
   ARBITRUM = 42161,
-  ARBITRUM_SEPOLIA = 42164,
+  ARBITRUM_SEPOLIA = 421614,
 }
 
 export interface Token {


### PR DESCRIPTION
修正 ArbitrumSepolia 的 `chainId` 以及調整代表顏色

現在用的 `#1b4add` 是從 Arbitrum 官網 css variable 來的，之前的顏色 `#17202c` 是 copilot 寫的，不太確定是根據什麼