### PR TITLE
[ASL-6480] Add comprehensive unit tests and refactor GraphQL initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ junit.xml
 
 .env
 .env.*
+
+coverage

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,24 +1,35 @@
 module.exports = api => {
   api.cache(true);
 
-  const config = {
-    presets: [
-      [
-        '@babel/preset-typescript',
-        {
-          allowNamespaces: true,
-          allowDeclareFields: true,
+  const presets = [
+    [
+      '@babel/preset-env',
+      {
+        // Target the current node version for tests
+        targets: {
+          node: 'current',
         },
-      ],
+      },
     ],
-    plugins: [
-      '@babel/plugin-proposal-export-namespace-from',
-      '@babel/plugin-proposal-optional-chaining',
-      '@babel/plugin-proposal-class-properties',
-      '@babel/plugin-syntax-dynamic-import',
-      '@babel/plugin-transform-runtime',
-      '@babel/plugin-transform-modules-commonjs',
+    [
+      '@babel/preset-typescript',
+      {
+        allowNamespaces: true,
+        allowDeclareFields: true,
+      },
     ],
+    // Add preset for React since it's in the project
+    '@babel/preset-react',
+  ];
+
+  const plugins = [
+    // This plugin is still useful to avoid duplicating helper functions
+    '@babel/plugin-transform-runtime',
+  ];
+
+  const config = {
+    presets,
+    plugins,
   };
 
   return config;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -442,15 +442,27 @@ function App() {
   }, [currentProvider]);
 
   const handleGetNetworkInfo = useCallback(async () => {
-    const networkInfo = await getNetworkInfo(1)
+    const answer = window.prompt('Enter chain ID (default: 1):', '1');
+    if (answer === null) {
+      return;
+    }
+    const chainId = Number(answer);
+    const networkInfo = await getNetworkInfo(chainId);
     console.log('-----------> networkInfo', networkInfo);
   }, []);
+
   const handleGetAllNetworkInfo = useCallback(async () => {
-    const allNetworkInfo = await getAllNetworkInfo()
+    const allNetworkInfo = await getAllNetworkInfo();
     console.log('-----------> allNetworkInfo', allNetworkInfo);
   }, []);
+
   const handleParseNetwork = useCallback(async () => {
-    const network = await parseNetwork(1);
+    const answer = window.prompt('Enter chain ID(default: 1):', '1');
+    if (answer === null) {
+      return;
+    }
+    const chainId = Number(answer);
+    const network = await parseNetwork(chainId);
     console.log('-----------> network', network);
   }, []);
 
@@ -520,9 +532,9 @@ function App() {
 
         <Group>
           <Title>Network Logic(log in console)</Title>
-          <Button onClick={handleGetNetworkInfo}>getNetworkInfo(chainId: 1)</Button>
+          <Button onClick={handleGetNetworkInfo}>getNetworkInfo</Button>
           <Button onClick={handleGetAllNetworkInfo}>getAllNetworkInfo</Button>
-          <Button onClick={handleParseNetwork}>parseNetwork(chainId: 1)</Button>
+          <Button onClick={handleParseNetwork}>parseNetwork</Button>
         </Group>
 
         <Group>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=22"
   },
   "jest": {
-    "testTimeout": 50000,
+    "testTimeout": 5000,
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/"
@@ -51,6 +51,10 @@
     "lerna": "5.1.8"
   },
   "devDependencies": {
+    "@babel/plugin-transform-runtime": "^7.28.0",
+    "@babel/preset-env": "^7.28.0",
+    "@babel/preset-react": "^7.27.1",
+    "@babel/preset-typescript": "^7.27.1",
     "@types/node": "^12.11.5",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",

--- a/packages/core/src/constants/backend.ts
+++ b/packages/core/src/constants/backend.ts
@@ -1,1 +1,2 @@
 export const WALLET_URL = 'https://wallet.qubic.app';
+export const GRAPHQL_ENDPOINT = `${WALLET_URL}/services/graphql-public`;

--- a/packages/core/src/types/backend.ts
+++ b/packages/core/src/types/backend.ts
@@ -5,5 +5,3 @@ export interface ApiConfig {
   apiSecret?: string;
   chainId: Network;
 }
-
-export const GRAPHQL_ENDPOINT = 'https://wallet.qubic.app/services/graphql-public';

--- a/packages/core/src/types/backend.ts
+++ b/packages/core/src/types/backend.ts
@@ -1,7 +1,9 @@
-import { Network } from "./chain";
+import { Network } from './chain';
 
 export interface ApiConfig {
   apiKey?: string;
   apiSecret?: string;
   chainId: Network;
 }
+
+export const GRAPHQL_ENDPOINT = 'https://wallet.qubic.app/services/graphql-public';

--- a/packages/core/src/utils/__test__/chain.test.ts
+++ b/packages/core/src/utils/__test__/chain.test.ts
@@ -1,16 +1,9 @@
 import NodeCache from 'node-cache';
 
-import {
-  getNetworkInfo,
-  getAllNetworkInfo,
-  parseNetwork,
-} from '../chain';
+import { getNetworkInfo, getAllNetworkInfo, parseNetwork, isNetwork, NATIVE_TOKEN_ADDRESS } from '../chain';
 import { GraphQLClient } from '../graphql';
 
-import {
-  Network,
-  ChainType,
-} from '../../types'; // 假設你的型別定義在 types.ts
+import { Network, ChainType } from '../../types'; // 假設你的型別定義在 types.ts
 
 import {
   mockNetworkInfo1,
@@ -28,26 +21,14 @@ import {
 jest.mock('../graphql');
 
 type NodeCacheWithMocks = typeof NodeCache & {
-  cacheGetMock: jest.Mock<any, any>;
-  cacheSetMock: jest.Mock<any, any>;
+  cacheGetMock: jest.Mock;
+  cacheSetMock: jest.Mock;
 };
 
 const { cacheGetMock, cacheSetMock } = NodeCache as NodeCacheWithMocks;
 
-const allNetworks = [
-  mockNetworkInfo1,
-  mockNetworkInfo2,
-  mockNetworkInfo3,
-  mockNetworkInfo4,
-  mockNetworkInfo5,
-];
-const allChains = [
-  mockChainInfo1,
-  mockChainInfo2,
-  mockChainInfo3,
-  mockChainInfo4,
-  mockChainInfo5,
-];
+const allNetworks = [mockNetworkInfo1, mockNetworkInfo2, mockNetworkInfo3, mockNetworkInfo4, mockNetworkInfo5];
+const allChains = [mockChainInfo1, mockChainInfo2, mockChainInfo3, mockChainInfo4, mockChainInfo5];
 
 describe('chain module (multi-network, typed)', () => {
   let mockRequest: jest.Mock;
@@ -68,7 +49,7 @@ describe('chain module (multi-network, typed)', () => {
       allChains.map((chain, i) => {
         mockRequest.mockResolvedValue({ chain: allChains[i] });
         return getNetworkInfo(chain.chainId);
-      })
+      }),
     );
     results.forEach((result, i) => {
       expect(result).toEqual(allNetworks[i]);
@@ -146,5 +127,175 @@ describe('chain module (multi-network, typed)', () => {
     });
 
     await expect(getNetworkInfo(99999)).rejects.toThrow('Unknown chainId: 99999');
+  });
+
+  it('should throw error when GraphQL request fails for getNetworkInfo', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    const errorMessage = 'Network request failed';
+    mockRequest.mockRejectedValue(new Error(errorMessage));
+
+    await expect(getNetworkInfo(Network.MAINNET)).rejects.toThrow(
+      `Failed to fetch chain info for ID ${Network.MAINNET}: ${errorMessage}`,
+    );
+  });
+
+  it('should throw error when GraphQL request fails for getAllNetworkInfo', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    const errorMessage = 'Network request failed';
+    mockRequest.mockRejectedValue(new Error(errorMessage));
+
+    await expect(getAllNetworkInfo()).rejects.toThrow(`Failed to fetch all chain info: ${errorMessage}`);
+  });
+
+  it('should throw error when GraphQL request fails for getAllNetworkInfo with type', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    const errorMessage = 'Network request failed';
+    mockRequest.mockRejectedValue(new Error(errorMessage));
+
+    await expect(getAllNetworkInfo(ChainType.MAINNET)).rejects.toThrow(
+      `Failed to fetch all chain info with type ${ChainType.MAINNET}: ${errorMessage}`,
+    );
+  });
+
+  it('should return cached data for getAllNetworkInfo', async () => {
+    cacheGetMock.mockReturnValue(allNetworks);
+
+    const result = await getAllNetworkInfo();
+
+    expect(result).toEqual(allNetworks);
+    expect(cacheGetMock).toHaveBeenCalledWith('allNetworkInfo:all');
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('should return cached data for getAllNetworkInfo with type', async () => {
+    const mainnetNetworks = allNetworks.filter(n => n.type === ChainType.MAINNET);
+    cacheGetMock.mockReturnValue(mainnetNetworks);
+
+    const result = await getAllNetworkInfo(ChainType.MAINNET);
+
+    expect(result).toEqual(mainnetNetworks);
+    expect(cacheGetMock).toHaveBeenCalledWith('allNetworkInfo:MAINNET');
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('should throw error if any node in getAllNetworkInfo has unknown chainId', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    const chainsWithInvalidId = [...allChains, { ...mockChainInfo1, chainId: 99999 }];
+    mockRequest.mockResolvedValue({ chains: { nodes: chainsWithInvalidId } });
+
+    await expect(getAllNetworkInfo()).rejects.toThrow('Unknown chainId: 99999');
+  });
+
+  it('should handle non-Error objects in getNetworkInfo catch block', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    mockRequest.mockRejectedValue('string error');
+
+    await expect(getNetworkInfo(Network.MAINNET)).rejects.toThrow(
+      `Failed to fetch chain info for ID ${Network.MAINNET}: string error`,
+    );
+  });
+
+  it('should handle non-Error objects in getAllNetworkInfo catch block', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    mockRequest.mockRejectedValue('string error');
+
+    await expect(getAllNetworkInfo()).rejects.toThrow('Failed to fetch all chain info: string error');
+  });
+
+  it('should throw error with detailed message when API returns unknown chainId in getNetworkInfo', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    mockRequest.mockResolvedValue({
+      chain: { ...mockChainInfo1, chainId: 99999 },
+    });
+
+    await expect(getNetworkInfo(99999)).rejects.toThrow('Unknown chainId: 99999. Check Network enum update status.');
+  });
+
+  it('should throw error with detailed message when API returns unknown chainId in getAllNetworkInfo', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    const chainsWithInvalidId = [...allChains, { ...mockChainInfo1, chainId: 88888 }];
+    mockRequest.mockResolvedValue({ chains: { nodes: chainsWithInvalidId } });
+
+    await expect(getAllNetworkInfo()).rejects.toThrow('Unknown chainId: 88888. Check Network enum update status.');
+  });
+
+  it('should throw error with detailed message when API returns unknown chainId in getAllNetworkInfo with type', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    const invalidMainnetChain = { ...mockChainInfo1, chainId: 77777, type: ChainType.MAINNET };
+    mockRequest.mockResolvedValue({
+      chains: { nodes: [invalidMainnetChain] },
+    });
+
+    await expect(getAllNetworkInfo(ChainType.MAINNET)).rejects.toThrow(
+      'Unknown chainId: 77777. Check Network enum update status.',
+    );
+  });
+
+  it('should test isNetwork function with valid Network values', () => {
+    expect(isNetwork(1)).toBe(true);
+    expect(isNetwork(137)).toBe(true);
+    expect(isNetwork('1')).toBe(true);
+    expect(isNetwork('137')).toBe(true);
+  });
+
+  it('should test isNetwork function with invalid values', () => {
+    expect(isNetwork(99999)).toBe(false);
+    expect(isNetwork('invalid')).toBe(false);
+    // @ts-expect-error Testing with invalid types
+    expect(isNetwork(null)).toBe(false);
+    // @ts-expect-error Testing with invalid types
+    expect(isNetwork(undefined)).toBe(false);
+  });
+
+  it('should test NATIVE_TOKEN_ADDRESS constant', () => {
+    expect(NATIVE_TOKEN_ADDRESS).toBe('0x0000000000000000000000000000000000455448');
+  });
+
+  it('should handle string chainId in getNetworkInfo', async () => {
+    cacheGetMock.mockReturnValue(undefined);
+    mockRequest.mockResolvedValue({ chain: mockChainInfo1 });
+
+    const result = await getNetworkInfo('1');
+
+    expect(result).toEqual(mockNetworkInfo1);
+    expect(cacheSetMock).toHaveBeenCalledWith('networkInfo:1', mockNetworkInfo1);
+  });
+
+  it('should handle string chainId in parseNetwork', async () => {
+    cacheGetMock.mockReturnValue(mockNetworkInfo1);
+
+    const result = await parseNetwork('1');
+
+    expect(result).toBe(Network.MAINNET);
+  });
+
+  it('should successfully parse valid Network when getNetworkInfo succeeds', async () => {
+    cacheGetMock.mockReturnValue(mockNetworkInfo1);
+
+    const result = await parseNetwork(Network.MAINNET);
+
+    expect(result).toBe(Network.MAINNET);
+  });
+
+  it('should successfully parse valid string Network when getNetworkInfo succeeds', async () => {
+    cacheGetMock.mockReturnValue(mockNetworkInfo2);
+
+    const result = await parseNetwork('137');
+
+    expect(result).toBe(Network.POLYGON);
+  });
+
+  it('should return null for invalid chainId in parseNetwork', async () => {
+    const result = await parseNetwork(99999);
+
+    expect(result).toBeNull();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('should return null for invalid string chainId in parseNetwork', async () => {
+    const result = await parseNetwork('invalid');
+
+    expect(result).toBeNull();
+    expect(mockRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/utils/__test__/graphql.test.ts
+++ b/packages/core/src/utils/__test__/graphql.test.ts
@@ -1,0 +1,352 @@
+import * as graphqlRequest from 'graphql-request';
+import serviceHeaderBuilder from '../serviceHeaderBuilder';
+import { GraphQLClient, initNetworkInfoFetcher, GRAPHQL_ENDPOINT, InitGqlConfig } from '../graphql';
+
+jest.mock('graphql-request', () => ({
+  request: jest.fn(),
+  ClientError: jest.requireActual('graphql-request').ClientError,
+}));
+
+const request = graphqlRequest.request as jest.Mock;
+
+jest.mock('../serviceHeaderBuilder');
+
+const MOCK_QUERY = 'query Test { test }';
+const MOCK_VARIABLES = { id: 1 };
+const MOCK_HEADERS = { 'x-api-key': 'test' };
+
+describe('GraphQL related functions', () => {
+  beforeEach(() => {
+    // Reset the singleton instance before each test
+    GraphQLClient._resetInstanceForTesting();
+    jest.clearAllMocks();
+  });
+
+  describe('initNetworkInfoFetcher and GraphQLClient.init', () => {
+    it('should return true on successful initialization with valid config', () => {
+      const config: InitGqlConfig = {
+        apiKey: 'test-api-key',
+        apiSecret: 'test-api-secret',
+        apiUri: 'https://test.api/graphql',
+      };
+      const result = initNetworkInfoFetcher(config);
+      expect(result).toBeUndefined();
+    });
+
+    it('should throw an error if apiKey is missing', () => {
+      const config = { apiSecret: 'test-api-secret' };
+      expect(() => {
+        // @ts-expect-error Testing missing apiKey
+        initNetworkInfoFetcher(config);
+      }).toThrow('Missing required configuration parameters');
+    });
+
+    it('should throw an error if apiSecret is missing', () => {
+      const config = { apiKey: 'test-api-key' };
+      expect(() => {
+        // @ts-expect-error Testing missing apiSecret
+        initNetworkInfoFetcher(config);
+      }).toThrow('Missing required configuration parameters');
+    });
+
+    it('should initialize successfully if apiUri is missing', () => {
+      const config = { apiKey: 'test-api-key', apiSecret: 'test-api-secret' };
+      const result = initNetworkInfoFetcher(config);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('GraphQLClient.getInstance', () => {
+    it('should throw an error if called before initialization', () => {
+      expect(() => {
+        GraphQLClient.getInstance();
+      }).toThrow('GraphQLClient not initialized. Please call initNetworkInfoFetcher() or init() first.');
+    });
+
+    it('should return an instance of GraphQLClient after initialization', () => {
+      const config: InitGqlConfig = { apiKey: 'test-api-key', apiSecret: 'test-api-secret' };
+      GraphQLClient.init(config);
+      const instance = GraphQLClient.getInstance();
+      expect(instance).toBeInstanceOf(GraphQLClient);
+    });
+  });
+
+  describe('GraphQLClient.request', () => {
+    const config: InitGqlConfig = {
+      apiKey: 'test-api-key',
+      apiSecret: 'test-api-secret',
+      apiUri: 'https://custom.api/graphql',
+    };
+
+    beforeEach(() => {
+      (serviceHeaderBuilder as jest.Mock).mockReturnValue(MOCK_HEADERS);
+      request.mockResolvedValue({ data: 'success' });
+    });
+
+    it('should make a request with custom apiUri if provided', async () => {
+      GraphQLClient.init(config);
+      const client = GraphQLClient.getInstance();
+
+      await client.request({ query: MOCK_QUERY, variables: MOCK_VARIABLES });
+
+      expect(serviceHeaderBuilder).toHaveBeenCalledWith({
+        serviceUri: config.apiUri,
+        httpMethod: 'POST',
+        apiKey: config.apiKey,
+        apiSecret: config.apiSecret,
+        body: expect.any(String),
+      });
+
+      expect(request).toHaveBeenCalledWith({
+        url: config.apiUri,
+        document: MOCK_QUERY,
+        variables: MOCK_VARIABLES,
+        requestHeaders: MOCK_HEADERS,
+      });
+    });
+
+    it('should make a request with default endpoint if apiUri is not provided', async () => {
+      const defaultConfig = { apiKey: 'key', apiSecret: 'secret' };
+      GraphQLClient.init(defaultConfig);
+      const client = GraphQLClient.getInstance();
+
+      await client.request({ query: MOCK_QUERY, variables: MOCK_VARIABLES });
+
+      expect(serviceHeaderBuilder).toHaveBeenCalledWith({
+        serviceUri: GRAPHQL_ENDPOINT, // Expect the default endpoint
+        httpMethod: 'POST',
+        apiKey: defaultConfig.apiKey,
+        apiSecret: defaultConfig.apiSecret,
+        body: expect.any(String),
+      });
+
+      expect(request).toHaveBeenCalledWith({
+        url: GRAPHQL_ENDPOINT, // Expect the default endpoint
+        document: MOCK_QUERY,
+        variables: MOCK_VARIABLES,
+        requestHeaders: MOCK_HEADERS,
+      });
+    });
+
+    it('should throw an error if the query is invalid and body cannot be created', async () => {
+      GraphQLClient.init(config);
+      const client = GraphQLClient.getInstance();
+
+      await expect(client.request({ query: '' })).rejects.toThrow('Invalid GraphQL query or operation name not found');
+    });
+  });
+
+  describe('GraphQLClient.resolveRequestDocument', () => {
+    it('should resolve a valid string document and extract operation name', () => {
+      const result = GraphQLClient.resolveRequestDocument('query MyTest { users { id } }');
+      expect(result.query).toBe('query MyTest { users { id } }');
+      expect(result.operationName).toBe('MyTest');
+    });
+
+    it('should handle an invalid string document gracefully', () => {
+      const result = GraphQLClient.resolveRequestDocument('this is not a valid query');
+      expect(result.query).toBe('this is not a valid query');
+      expect(result.operationName).toBeUndefined();
+    });
+
+    it('should resolve a DocumentNode document', async () => {
+      const { parse } = await import('graphql');
+      const docNode = parse('query MyTestNode { posts { title } }');
+      const result = GraphQLClient.resolveRequestDocument(docNode);
+      expect(result.query).toContain('MyTestNode');
+      expect(result.operationName).toBe('MyTestNode');
+    });
+  });
+
+  describe('Error Handling', () => {
+    const config: InitGqlConfig = {
+      apiKey: 'test-api-key',
+      apiSecret: 'test-api-secret',
+    };
+
+    beforeEach(() => {
+      jest.clearAllTimers();
+      (serviceHeaderBuilder as jest.Mock).mockReturnValue(MOCK_HEADERS);
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    it('should handle various network errors and preserve stack trace', async () => {
+      // Use a config with 0 retries to avoid infinite loops
+      const configNoRetry: InitGqlConfig = {
+        apiKey: 'test-api-key',
+        apiSecret: 'test-api-secret',
+      };
+
+      GraphQLClient.init(configNoRetry);
+      const client = GraphQLClient.getInstance();
+
+      const originalError = new Error('Network connection failed');
+      originalError.stack = 'Original stack trace';
+
+      request.mockRejectedValue(originalError);
+
+      await expect(client.request({ query: MOCK_QUERY })).rejects.toThrow(Error);
+      await expect(client.request({ query: MOCK_QUERY })).rejects.toThrow('Network connection failed');
+    });
+
+    it('should handle serviceHeaderBuilder errors and preserve stack trace', async () => {
+      GraphQLClient.init(config);
+      const client = GraphQLClient.getInstance();
+
+      const originalError = new Error('Header generation failed');
+      originalError.stack = 'Header error stack';
+
+      (serviceHeaderBuilder as jest.Mock).mockImplementation(() => {
+        throw originalError;
+      });
+
+      try {
+        await client.request({ query: MOCK_QUERY });
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        const graphqlError = error as Error;
+        expect(graphqlError.message).toBe('Header generation failed');
+      }
+    });
+
+    it('should handle retryable vs non-retryable errors correctly', async () => {
+      const configNoRetry: InitGqlConfig = {
+        apiKey: 'test-api-key',
+        apiSecret: 'test-api-secret',
+      };
+
+      GraphQLClient.init(configNoRetry);
+      const client = GraphQLClient.getInstance();
+
+      const retryableError = new Error('ECONNRESET');
+      request.mockRejectedValue(retryableError);
+
+      await expect(client.request({ query: MOCK_QUERY })).rejects.toThrow(Error);
+      await expect(client.request({ query: MOCK_QUERY })).rejects.toThrow('ECONNRESET');
+
+      // Test non-retryable error (should also be wrapped in Error)
+      const nonRetryableError = new Error('Invalid request');
+      request.mockRejectedValue(nonRetryableError);
+
+      await expect(client.request({ query: MOCK_QUERY })).rejects.toThrow(Error);
+      await expect(client.request({ query: MOCK_QUERY })).rejects.toThrow('Invalid request');
+    });
+  });
+
+  describe('Configuration with timeout and retry', () => {
+    it('should accept timeout and retryAttempts in config', () => {
+      const config: InitGqlConfig = {
+        apiKey: 'test-api-key',
+        apiSecret: 'test-api-secret',
+      };
+
+      const result = initNetworkInfoFetcher(config);
+      expect(result).toBeUndefined();
+    });
+
+    it('should treat configurations with same timeout/retry as identical', () => {
+      const config1: InitGqlConfig = {
+        apiKey: 'test-api-key',
+        apiSecret: 'test-api-secret',
+      };
+
+      const config2: InitGqlConfig = {
+        apiKey: 'test-api-key',
+        apiSecret: 'test-api-secret',
+      };
+
+      GraphQLClient.init(config1);
+      const result = GraphQLClient.init(config2);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('GraphQLClient.init with configuration conflicts', () => {
+    beforeEach(() => {
+      GraphQLClient._resetInstanceForTesting();
+    });
+
+    it('should throw an error when initializing with different configuration after first initialization', () => {
+      const firstConfig: InitGqlConfig = {
+        apiKey: 'first-key',
+        apiSecret: 'first-secret',
+        apiUri: 'https://first.api/graphql',
+      };
+
+      const secondConfig: InitGqlConfig = {
+        apiKey: 'second-key',
+        apiSecret: 'second-secret',
+        apiUri: 'https://second.api/graphql',
+      };
+
+      // First initialization should succeed
+      const firstResult = GraphQLClient.init(firstConfig);
+      expect(firstResult).toBeUndefined();
+
+      // Second initialization with different config should throw
+      expect(() => {
+        GraphQLClient.init(secondConfig);
+      }).toThrow('GraphQLClient already initialized with a different configuration.');
+    });
+
+    it('should throw an error when apiKey differs in subsequent initialization', () => {
+      const firstConfig: InitGqlConfig = {
+        apiKey: 'first-key',
+        apiSecret: 'same-secret',
+      };
+
+      const secondConfig: InitGqlConfig = {
+        apiKey: 'different-key',
+        apiSecret: 'same-secret',
+      };
+
+      GraphQLClient.init(firstConfig);
+
+      expect(() => {
+        GraphQLClient.init(secondConfig);
+      }).toThrow('GraphQLClient already initialized with a different configuration.');
+    });
+
+    it('should throw an error when apiSecret differs in subsequent initialization', () => {
+      const firstConfig: InitGqlConfig = {
+        apiKey: 'same-key',
+        apiSecret: 'first-secret',
+      };
+
+      const secondConfig: InitGqlConfig = {
+        apiKey: 'same-key',
+        apiSecret: 'different-secret',
+      };
+
+      GraphQLClient.init(firstConfig);
+
+      expect(() => {
+        GraphQLClient.init(secondConfig);
+      }).toThrow('GraphQLClient already initialized with a different configuration.');
+    });
+
+    it('should throw an error when apiUri differs in subsequent initialization', () => {
+      const firstConfig: InitGqlConfig = {
+        apiKey: 'same-key',
+        apiSecret: 'same-secret',
+        apiUri: 'https://first.api/graphql',
+      };
+
+      const secondConfig: InitGqlConfig = {
+        apiKey: 'same-key',
+        apiSecret: 'same-secret',
+        apiUri: 'https://different.api/graphql',
+      };
+
+      GraphQLClient.init(firstConfig);
+
+      expect(() => {
+        GraphQLClient.init(secondConfig);
+      }).toThrow('GraphQLClient already initialized with a different configuration.');
+    });
+  });
+});

--- a/packages/core/src/utils/__test__/serviceHeaderBuilder.test.ts
+++ b/packages/core/src/utils/__test__/serviceHeaderBuilder.test.ts
@@ -1,0 +1,240 @@
+import HmacSHA256 from 'crypto-js/hmac-sha256';
+import Base64 from 'crypto-js/enc-base64';
+import serviceHeaderBuilder from '../serviceHeaderBuilder';
+
+// Mock crypto-js modules
+jest.mock('crypto-js/hmac-sha256');
+jest.mock('crypto-js/enc-base64');
+
+const mockHmacSHA256 = HmacSHA256 as jest.MockedFunction<typeof HmacSHA256>;
+const mockBase64 = Base64 as jest.Mocked<typeof Base64>;
+
+describe('serviceHeaderBuilder', () => {
+  const mockApiKey = 'test-api-key';
+  const mockApiSecret = 'test-api-secret';
+  const mockServiceUri = 'https://api.example.com/endpoint?param=value';
+  const mockAccessToken = 'test-access-token';
+  const mockSignature = 'mock-signature';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock Date.now() to return a fixed timestamp
+    jest.spyOn(Date, 'now').mockReturnValue(1234567890);
+
+    // Mock crypto-js functions
+    const mockHashResult = {
+      toString: jest.fn().mockReturnValue(mockSignature),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockHmacSHA256.mockReturnValue(mockHashResult as any);
+    mockBase64.toString = jest.fn().mockReturnValue(mockSignature);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return empty object when apiKey is missing', () => {
+    const result = serviceHeaderBuilder({
+      serviceUri: mockServiceUri,
+      apiKey: '',
+      apiSecret: mockApiSecret,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when apiSecret is missing', () => {
+    const result = serviceHeaderBuilder({
+      serviceUri: mockServiceUri,
+      apiKey: mockApiKey,
+      apiSecret: '',
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when both apiKey and apiSecret are missing', () => {
+    const result = serviceHeaderBuilder({
+      serviceUri: mockServiceUri,
+      apiKey: '',
+      apiSecret: '',
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('should generate headers with default GET method and empty body', () => {
+    const result = serviceHeaderBuilder({
+      serviceUri: mockServiceUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+    });
+
+    expect(mockHmacSHA256).toHaveBeenCalledWith('1234567890GET/endpoint?param=value', mockApiSecret);
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+    });
+  });
+
+  it('should generate headers with custom HTTP method', () => {
+    const result = serviceHeaderBuilder({
+      httpMethod: 'POST',
+      serviceUri: mockServiceUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+    });
+
+    expect(mockHmacSHA256).toHaveBeenCalledWith('1234567890POST/endpoint?param=value', mockApiSecret);
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+    });
+  });
+
+  it('should generate headers with custom body', () => {
+    const mockBody = JSON.stringify({ test: 'data' });
+
+    const result = serviceHeaderBuilder({
+      httpMethod: 'POST',
+      serviceUri: mockServiceUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+      body: mockBody,
+    });
+
+    expect(mockHmacSHA256).toHaveBeenCalledWith(`1234567890POST/endpoint?param=value${mockBody}`, mockApiSecret);
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+    });
+  });
+
+  it('should include Authorization header when accessToken is provided', () => {
+    const result = serviceHeaderBuilder({
+      serviceUri: mockServiceUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+      accessToken: mockAccessToken,
+    });
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+      Authorization: `Bearer ${mockAccessToken}`,
+    });
+  });
+
+  it('should not include Authorization header when accessToken is null', () => {
+    const result = serviceHeaderBuilder({
+      serviceUri: mockServiceUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+      accessToken: null,
+    });
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+    });
+  });
+
+  it('should handle URL without query parameters', () => {
+    const simpleUri = 'https://api.example.com/endpoint';
+
+    const result = serviceHeaderBuilder({
+      serviceUri: simpleUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+    });
+
+    expect(mockHmacSHA256).toHaveBeenCalledWith('1234567890GET/endpoint', mockApiSecret);
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+    });
+  });
+
+  it('should handle URL with only pathname', () => {
+    const pathOnlyUri = 'https://api.example.com/';
+
+    const result = serviceHeaderBuilder({
+      serviceUri: pathOnlyUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+    });
+
+    expect(mockHmacSHA256).toHaveBeenCalledWith('1234567890GET/', mockApiSecret);
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+    });
+  });
+
+  it('should handle body as null', () => {
+    const result = serviceHeaderBuilder({
+      serviceUri: mockServiceUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+      body: null,
+    });
+
+    expect(mockHmacSHA256).toHaveBeenCalledWith('1234567890GET/endpoint?param=valuenull', mockApiSecret);
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+    });
+  });
+
+  it('should handle complex query parameters', () => {
+    const complexUri = 'https://api.example.com/endpoint?param1=value1&param2=value2&param3=value%20with%20spaces';
+
+    const result = serviceHeaderBuilder({
+      serviceUri: complexUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+    });
+
+    expect(mockHmacSHA256).toHaveBeenCalledWith(
+      '1234567890GET/endpoint?param1=value1&param2=value2&param3=value%20with%20spaces',
+      mockApiSecret,
+    );
+
+    expect(result).toEqual({
+      'X-Qubic-Api-Key': mockApiKey,
+      'X-Qubic-Ts': '1234567890',
+      'X-Qubic-Sign': mockSignature,
+    });
+  });
+
+  it('should use current timestamp from Date.now()', () => {
+    const mockTimestamp = 9876543210;
+    jest.spyOn(Date, 'now').mockReturnValue(mockTimestamp);
+
+    const result = serviceHeaderBuilder({
+      serviceUri: mockServiceUri,
+      apiKey: mockApiKey,
+      apiSecret: mockApiSecret,
+    });
+
+    expect(mockHmacSHA256).toHaveBeenCalledWith(`${mockTimestamp}GET/endpoint?param=value`, mockApiSecret);
+
+    expect(result['X-Qubic-Ts']).toBe(mockTimestamp.toString());
+  });
+});

--- a/packages/core/src/utils/chain.ts
+++ b/packages/core/src/utils/chain.ts
@@ -82,7 +82,7 @@ interface ChainsResult {
   };
 }
 
-export async function getNetworkInfo(id: string | number): Promise<NetworkInfo | null> {
+export async function getNetworkInfo(id: number): Promise<NetworkInfo> {
   const cacheKey = `networkInfo:${id}`;
   const cachedData = cache.get<NetworkInfo>(cacheKey);
 
@@ -102,11 +102,12 @@ export async function getNetworkInfo(id: string | number): Promise<NetworkInfo |
     );
   }
 
-  if (!isNetwork(chainInfo.chain.chainId)) {
-    throw new Error(`Unknown chainId: ${chainInfo.chain.chainId}. Check Network enum update status.`);
+  const apiChain = chainInfo.chain;
+  if (!isNetwork(apiChain.chainId)) {
+    throw new Error(`Unknown chainId: ${apiChain.chainId}. Check Network enum update status.`);
   }
 
-  const networkInfo = getNetworkFromApiChain(chainInfo.chain);
+  const networkInfo = getNetworkFromApiChain(apiChain);
   cache.set(cacheKey, networkInfo);
   return networkInfo;
 }
@@ -143,9 +144,13 @@ export async function getAllNetworkInfo(type?: ChainType): Promise<NetworkInfo[]
   return allNetworkInfo;
 }
 
-export const parseNetwork = async (chainId: number | string): Promise<Network | null> => {
-  if (!isNetwork(chainId)) return null;
-  return Number(chainId) as Network;
+export const parseNetwork = async (chainId: number): Promise<Network | null> => {
+  try {
+    const networkInfo = await getNetworkInfo(chainId);
+    return networkInfo.chainId;
+  } catch (error) {
+    return null;
+  }
 };
 
 export const NATIVE_TOKEN_ADDRESS = '0x0000000000000000000000000000000000455448';

--- a/packages/core/src/utils/chain.ts
+++ b/packages/core/src/utils/chain.ts
@@ -44,7 +44,9 @@ const CHAINS = gql`
 `;
 
 function isEnumValue<T extends Record<string, unknown>>(enumObj: T, value: unknown): value is T[keyof T] {
-  return Object.values(enumObj).filter(v => typeof v === 'number').includes(Number(value));
+  return Object.values(enumObj)
+    .filter(v => typeof v === 'number')
+    .includes(Number(value));
 }
 
 export function isNetwork(chainId: number | string): chainId is Network {
@@ -96,8 +98,7 @@ export async function getNetworkInfo(id: string | number): Promise<NetworkInfo |
     });
   } catch (error) {
     throw new Error(
-      `Failed to fetch chain info for ID ${id}: ` +
-      `${error instanceof Error ? error.message : String(error)}`
+      `Failed to fetch chain info for ID ${id}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 
@@ -127,7 +128,7 @@ export async function getAllNetworkInfo(type?: ChainType): Promise<NetworkInfo[]
   } catch (error) {
     throw new Error(
       `Failed to fetch all chain info${type ? ` with type ${type}` : ''}: ` +
-      `${error instanceof Error ? error.message : String(error)}`
+        `${error instanceof Error ? error.message : String(error)}`,
     );
   }
 
@@ -143,15 +144,7 @@ export async function getAllNetworkInfo(type?: ChainType): Promise<NetworkInfo[]
 }
 
 export const parseNetwork = async (chainId: number | string): Promise<Network | null> => {
-  if (!isNetwork(chainId)) {
-    return null;
-  }
-  const correspondNetworkInfo = await getNetworkInfo(chainId);
-  if (!correspondNetworkInfo) {
-    throw new Error(
-      `Chain ID ${chainId} is Network but unknown to API. Check Network enum update status.`
-    );
-  }
+  if (!isNetwork(chainId)) return null;
   return Number(chainId) as Network;
 };
 

--- a/packages/core/src/utils/serviceHeaderBuilder.ts
+++ b/packages/core/src/utils/serviceHeaderBuilder.ts
@@ -17,7 +17,7 @@ const serviceHeaderBuilder = ({
   apiKey,
   body = '',
   accessToken,
-}: BuilderInput): HeadersInit => {
+}: BuilderInput): Record<string, string> => {
   if (!apiKey || !apiSecret) {
     return {};
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.27.3.tgz#cc49c2ac222d69b889bf34c795f537c0c6311111"
   integrity sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==
 
+"@babel/compat-data@^7.27.7", "@babel/compat-data@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.0.tgz#9fc6fd58c2a6a15243cd13983224968392070790"
+  integrity sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==
+
 "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.27.3.tgz#d7d05502bccede3cab36373ed142e6a1df554c2f"
@@ -70,7 +75,25 @@
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
 
-"@babel/helper-compilation-targets@^7.27.2":
+"@babel/generator@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.0.tgz#9cc2f7bd6eb054d77dc66c2664148a0c5118acd2"
+  integrity sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==
+  dependencies:
+    "@babel/parser" "^7.28.0"
+    "@babel/types" "^7.28.0"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
+"@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3":
+  version "7.27.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz#f31fd86b915fc4daf1f3ac6976c59be7084ed9c5"
+  integrity sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==
+  dependencies:
+    "@babel/types" "^7.27.3"
+
+"@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz#46a0f6efab808d51d29ce96858dd10ce8732733d"
   integrity sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==
@@ -80,6 +103,52 @@
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz#5bee4262a6ea5ddc852d0806199eb17ca3de9281"
+  integrity sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-member-expression-to-functions" "^7.27.1"
+    "@babel/helper-optimise-call-expression" "^7.27.1"
+    "@babel/helper-replace-supers" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+    semver "^6.3.1"
+
+"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz#05b0882d97ba1d4d03519e4bce615d70afa18c53"
+  integrity sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    regexpu-core "^6.2.0"
+    semver "^6.3.1"
+
+"@babel/helper-define-polyfill-provider@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz#742ccf1cb003c07b48859fc9fa2c1bbe40e5f753"
+  integrity sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    debug "^4.4.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.22.10"
+
+"@babel/helper-globals@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
+  integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
+
+"@babel/helper-member-expression-to-functions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz#ea1211276be93e798ce19037da6f06fbb994fa44"
+  integrity sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==
+  dependencies:
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
 "@babel/helper-module-imports@^7.12.13":
   version "7.16.7"
@@ -96,7 +165,7 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
-"@babel/helper-module-transforms@^7.27.3":
+"@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz#db0bbcfba5802f9ef7870705a7ef8788508ede02"
   integrity sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==
@@ -105,7 +174,14 @@
     "@babel/helper-validator-identifier" "^7.27.1"
     "@babel/traverse" "^7.27.3"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0":
+"@babel/helper-optimise-call-expression@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz#c65221b61a643f3e62705e5dd2b5f115e35f9200"
+  integrity sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==
+  dependencies:
+    "@babel/types" "^7.27.1"
+
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz#ddb2f876534ff8013e6c2b299bf4d39b3c51d44c"
   integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
@@ -114,6 +190,32 @@
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
   integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
+
+"@babel/helper-remap-async-to-generator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz#4601d5c7ce2eb2aea58328d43725523fcd362ce6"
+  integrity sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-wrap-function" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+
+"@babel/helper-replace-supers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz#b1ed2d634ce3bdb730e4b52de30f8cccfd692bc0"
+  integrity sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.27.1"
+    "@babel/helper-optimise-call-expression" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+
+"@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz#62bb91b3abba8c7f1fec0252d9dbea11b3ee7a56"
+  integrity sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==
+  dependencies:
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
@@ -134,6 +236,15 @@
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
   integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
+
+"@babel/helper-wrap-function@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz#b88285009c31427af318d4fe37651cd62a142409"
+  integrity sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==
+  dependencies:
+    "@babel/template" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
 "@babel/helpers@^7.27.3":
   version "7.27.3"
@@ -168,6 +279,57 @@
   dependencies:
     "@babel/types" "^7.27.3"
 
+"@babel/parser@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.0.tgz#979829fbab51a29e13901e5a80713dbcb840825e"
+  integrity sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==
+  dependencies:
+    "@babel/types" "^7.28.0"
+
+"@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz#61dd8a8e61f7eb568268d1b5f129da3eee364bf9"
+  integrity sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+
+"@babel/plugin-bugfix-safari-class-field-initializer-scope@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz#43f70a6d7efd52370eefbdf55ae03d91b293856d"
+  integrity sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz#beb623bd573b8b6f3047bd04c32506adc3e58a72"
+  integrity sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz#e134a5479eb2ba9c02714e8c1ebf1ec9076124fd"
+  integrity sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/plugin-transform-optional-chaining" "^7.27.1"
+
+"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz#bb1c25af34d75115ce229a1de7fa44bf8f955670"
+  integrity sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+
+"@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
+  version "7.21.0-placeholder-for-preset-env.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
+  integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
+
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
@@ -196,7 +358,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-import-attributes@^7.24.7":
+"@babel/plugin-syntax-import-assertions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz#88894aefd2b03b5ee6ad1562a7c8e1587496aecd"
+  integrity sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-syntax-import-attributes@^7.24.7", "@babel/plugin-syntax-import-attributes@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz#34c017d54496f9b11b61474e7ea3dfd5563ffe07"
   integrity sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==
@@ -224,7 +393,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-jsx@^7.7.2":
+"@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.7.2":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz#2f9beb5eff30fa507c5532d107daac7b888fa34c"
   integrity sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==
@@ -287,12 +456,581 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.7.2":
+"@babel/plugin-syntax-typescript@^7.27.1", "@babel/plugin-syntax-typescript@^7.7.2":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz#5147d29066a793450f220c63fa3a9431b7e6dd18"
   integrity sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz#d49a3b3e6b52e5be6740022317580234a6a47357"
+  integrity sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.6"
+
+"@babel/plugin-transform-arrow-functions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz#6e2061067ba3ab0266d834a9f94811196f2aba9a"
+  integrity sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-async-generator-functions@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz#1276e6c7285ab2cd1eccb0bc7356b7a69ff842c2"
+  integrity sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-remap-async-to-generator" "^7.27.1"
+    "@babel/traverse" "^7.28.0"
+
+"@babel/plugin-transform-async-to-generator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz#9a93893b9379b39466c74474f55af03de78c66e7"
+  integrity sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-remap-async-to-generator" "^7.27.1"
+
+"@babel/plugin-transform-block-scoped-functions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz#558a9d6e24cf72802dd3b62a4b51e0d62c0f57f9"
+  integrity sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-block-scoping@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz#e7c50cbacc18034f210b93defa89638666099451"
+  integrity sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-class-properties@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz#dd40a6a370dfd49d32362ae206ddaf2bb082a925"
+  integrity sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-class-static-block@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz#7e920d5625b25bbccd3061aefbcc05805ed56ce4"
+  integrity sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-classes@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.0.tgz#12fa46cffc32a6e084011b650539e880add8a0f8"
+  integrity sha512-IjM1IoJNw72AZFlj33Cu8X0q2XK/6AaVC3jQu+cgQ5lThWD5ajnuUAml80dqRmOhmPkTH8uAwnpMu9Rvj0LTRA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.3"
+    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-replace-supers" "^7.27.1"
+    "@babel/traverse" "^7.28.0"
+
+"@babel/plugin-transform-computed-properties@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz#81662e78bf5e734a97982c2b7f0a793288ef3caa"
+  integrity sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/template" "^7.27.1"
+
+"@babel/plugin-transform-destructuring@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz#0f156588f69c596089b7d5b06f5af83d9aa7f97a"
+  integrity sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/traverse" "^7.28.0"
+
+"@babel/plugin-transform-dotall-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz#aa6821de864c528b1fecf286f0a174e38e826f4d"
+  integrity sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-duplicate-keys@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz#f1fbf628ece18e12e7b32b175940e68358f546d1"
+  integrity sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-duplicate-named-capturing-groups-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz#5043854ca620a94149372e69030ff8cb6a9eb0ec"
+  integrity sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-dynamic-import@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz#4c78f35552ac0e06aa1f6e3c573d67695e8af5a4"
+  integrity sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-explicit-resource-management@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz#45be6211b778dbf4b9d54c4e8a2b42fa72e09a1a"
+  integrity sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-transform-destructuring" "^7.28.0"
+
+"@babel/plugin-transform-exponentiation-operator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz#fc497b12d8277e559747f5a3ed868dd8064f83e1"
+  integrity sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-export-namespace-from@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz#71ca69d3471edd6daa711cf4dfc3400415df9c23"
+  integrity sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-for-of@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz#bc24f7080e9ff721b63a70ac7b2564ca15b6c40a"
+  integrity sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+
+"@babel/plugin-transform-function-name@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz#4d0bf307720e4dce6d7c30fcb1fd6ca77bdeb3a7"
+  integrity sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+
+"@babel/plugin-transform-json-strings@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz#a2e0ce6ef256376bd527f290da023983527a4f4c"
+  integrity sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-literals@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz#baaefa4d10a1d4206f9dcdda50d7d5827bb70b24"
+  integrity sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-logical-assignment-operators@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz#890cb20e0270e0e5bebe3f025b434841c32d5baa"
+  integrity sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-member-expression-literals@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz#37b88ba594d852418e99536f5612f795f23aeaf9"
+  integrity sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-modules-amd@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz#a4145f9d87c2291fe2d05f994b65dba4e3e7196f"
+  integrity sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-modules-commonjs@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz#8e44ed37c2787ecc23bdc367f49977476614e832"
+  integrity sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-modules-systemjs@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz#00e05b61863070d0f3292a00126c16c0e024c4ed"
+  integrity sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+
+"@babel/plugin-transform-modules-umd@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz#63f2cf4f6dc15debc12f694e44714863d34cd334"
+  integrity sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-named-capturing-groups-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz#f32b8f7818d8fc0cc46ee20a8ef75f071af976e1"
+  integrity sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-new-target@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz#259c43939728cad1706ac17351b7e6a7bea1abeb"
+  integrity sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-nullish-coalescing-operator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz#4f9d3153bf6782d73dd42785a9d22d03197bc91d"
+  integrity sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-numeric-separator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz#614e0b15cc800e5997dadd9bd6ea524ed6c819c6"
+  integrity sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-object-rest-spread@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz#d23021857ffd7cd809f54d624299b8086402ed8d"
+  integrity sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-transform-destructuring" "^7.28.0"
+    "@babel/plugin-transform-parameters" "^7.27.7"
+    "@babel/traverse" "^7.28.0"
+
+"@babel/plugin-transform-object-super@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz#1c932cd27bf3874c43a5cac4f43ebf970c9871b5"
+  integrity sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-replace-supers" "^7.27.1"
+
+"@babel/plugin-transform-optional-catch-binding@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz#84c7341ebde35ccd36b137e9e45866825072a30c"
+  integrity sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-optional-chaining@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz#874ce3c4f06b7780592e946026eb76a32830454f"
+  integrity sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+
+"@babel/plugin-transform-parameters@^7.27.7":
+  version "7.27.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz#1fd2febb7c74e7d21cf3b05f7aebc907940af53a"
+  integrity sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-private-methods@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz#fdacbab1c5ed81ec70dfdbb8b213d65da148b6af"
+  integrity sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-private-property-in-object@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz#4dbbef283b5b2f01a21e81e299f76e35f900fb11"
+  integrity sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-property-literals@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz#07eafd618800591e88073a0af1b940d9a42c6424"
+  integrity sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-react-display-name@^7.27.1":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz#6f20a7295fea7df42eb42fed8f896813f5b934de"
+  integrity sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-react-jsx-development@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz#47ff95940e20a3a70e68ad3d4fcb657b647f6c98"
+  integrity sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==
+  dependencies:
+    "@babel/plugin-transform-react-jsx" "^7.27.1"
+
+"@babel/plugin-transform-react-jsx@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz#1023bc94b78b0a2d68c82b5e96aed573bcfb9db0"
+  integrity sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/types" "^7.27.1"
+
+"@babel/plugin-transform-react-pure-annotations@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz#339f1ce355eae242e0649f232b1c68907c02e879"
+  integrity sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-regenerator@^7.28.0":
+  version "7.28.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz#bde80603442ff4bb4e910bc8b35485295d556ab1"
+  integrity sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-regexp-modifiers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz#df9ba5577c974e3f1449888b70b76169998a6d09"
+  integrity sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-reserved-words@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz#40fba4878ccbd1c56605a4479a3a891ac0274bb4"
+  integrity sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-runtime@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.0.tgz#462e79008cc7bdac03e4c5e1765b9de2bcd31c21"
+  integrity sha512-dGopk9nZrtCs2+nfIem25UuHyt5moSJamArzIoh9/vezUQPmYDOzjaHDCkAzuGJibCIkPup8rMT2+wYB6S73cA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    babel-plugin-polyfill-corejs2 "^0.4.14"
+    babel-plugin-polyfill-corejs3 "^0.13.0"
+    babel-plugin-polyfill-regenerator "^0.6.5"
+    semver "^6.3.1"
+
+"@babel/plugin-transform-shorthand-properties@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz#532abdacdec87bfee1e0ef8e2fcdee543fe32b90"
+  integrity sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-spread@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz#1a264d5fc12750918f50e3fe3e24e437178abb08"
+  integrity sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+
+"@babel/plugin-transform-sticky-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz#18984935d9d2296843a491d78a014939f7dcd280"
+  integrity sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-template-literals@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz#1a0eb35d8bb3e6efc06c9fd40eb0bcef548328b8"
+  integrity sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-typeof-symbol@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz#70e966bb492e03509cf37eafa6dcc3051f844369"
+  integrity sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-typescript@^7.27.1":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz#796cbd249ab56c18168b49e3e1d341b72af04a6b"
+  integrity sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.3"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.27.1"
+
+"@babel/plugin-transform-unicode-escapes@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz#3e3143f8438aef842de28816ece58780190cf806"
+  integrity sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-unicode-property-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz#bdfe2d3170c78c5691a3c3be934c8c0087525956"
+  integrity sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-unicode-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz#25948f5c395db15f609028e370667ed8bae9af97"
+  integrity sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-unicode-sets-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz#6ab706d10f801b5c72da8bb2548561fa04193cd1"
+  integrity sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/preset-env@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.28.0.tgz#d23a6bc17b43227d11db77081a0779c706b5569c"
+  integrity sha512-VmaxeGOwuDqzLl5JUkIRM1X2Qu2uKGxHEQWh+cvvbl7JuJRgKGJSfsEF/bUaxFhJl/XAyxBe7q7qSuTbKFuCyg==
+  dependencies:
+    "@babel/compat-data" "^7.28.0"
+    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.27.1"
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.27.1"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.27.1"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.27.1"
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.27.1"
+    "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
+    "@babel/plugin-syntax-import-assertions" "^7.27.1"
+    "@babel/plugin-syntax-import-attributes" "^7.27.1"
+    "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
+    "@babel/plugin-transform-arrow-functions" "^7.27.1"
+    "@babel/plugin-transform-async-generator-functions" "^7.28.0"
+    "@babel/plugin-transform-async-to-generator" "^7.27.1"
+    "@babel/plugin-transform-block-scoped-functions" "^7.27.1"
+    "@babel/plugin-transform-block-scoping" "^7.28.0"
+    "@babel/plugin-transform-class-properties" "^7.27.1"
+    "@babel/plugin-transform-class-static-block" "^7.27.1"
+    "@babel/plugin-transform-classes" "^7.28.0"
+    "@babel/plugin-transform-computed-properties" "^7.27.1"
+    "@babel/plugin-transform-destructuring" "^7.28.0"
+    "@babel/plugin-transform-dotall-regex" "^7.27.1"
+    "@babel/plugin-transform-duplicate-keys" "^7.27.1"
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex" "^7.27.1"
+    "@babel/plugin-transform-dynamic-import" "^7.27.1"
+    "@babel/plugin-transform-explicit-resource-management" "^7.28.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.27.1"
+    "@babel/plugin-transform-export-namespace-from" "^7.27.1"
+    "@babel/plugin-transform-for-of" "^7.27.1"
+    "@babel/plugin-transform-function-name" "^7.27.1"
+    "@babel/plugin-transform-json-strings" "^7.27.1"
+    "@babel/plugin-transform-literals" "^7.27.1"
+    "@babel/plugin-transform-logical-assignment-operators" "^7.27.1"
+    "@babel/plugin-transform-member-expression-literals" "^7.27.1"
+    "@babel/plugin-transform-modules-amd" "^7.27.1"
+    "@babel/plugin-transform-modules-commonjs" "^7.27.1"
+    "@babel/plugin-transform-modules-systemjs" "^7.27.1"
+    "@babel/plugin-transform-modules-umd" "^7.27.1"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.27.1"
+    "@babel/plugin-transform-new-target" "^7.27.1"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.27.1"
+    "@babel/plugin-transform-numeric-separator" "^7.27.1"
+    "@babel/plugin-transform-object-rest-spread" "^7.28.0"
+    "@babel/plugin-transform-object-super" "^7.27.1"
+    "@babel/plugin-transform-optional-catch-binding" "^7.27.1"
+    "@babel/plugin-transform-optional-chaining" "^7.27.1"
+    "@babel/plugin-transform-parameters" "^7.27.7"
+    "@babel/plugin-transform-private-methods" "^7.27.1"
+    "@babel/plugin-transform-private-property-in-object" "^7.27.1"
+    "@babel/plugin-transform-property-literals" "^7.27.1"
+    "@babel/plugin-transform-regenerator" "^7.28.0"
+    "@babel/plugin-transform-regexp-modifiers" "^7.27.1"
+    "@babel/plugin-transform-reserved-words" "^7.27.1"
+    "@babel/plugin-transform-shorthand-properties" "^7.27.1"
+    "@babel/plugin-transform-spread" "^7.27.1"
+    "@babel/plugin-transform-sticky-regex" "^7.27.1"
+    "@babel/plugin-transform-template-literals" "^7.27.1"
+    "@babel/plugin-transform-typeof-symbol" "^7.27.1"
+    "@babel/plugin-transform-unicode-escapes" "^7.27.1"
+    "@babel/plugin-transform-unicode-property-regex" "^7.27.1"
+    "@babel/plugin-transform-unicode-regex" "^7.27.1"
+    "@babel/plugin-transform-unicode-sets-regex" "^7.27.1"
+    "@babel/preset-modules" "0.1.6-no-external-plugins"
+    babel-plugin-polyfill-corejs2 "^0.4.14"
+    babel-plugin-polyfill-corejs3 "^0.13.0"
+    babel-plugin-polyfill-regenerator "^0.6.5"
+    core-js-compat "^3.43.0"
+    semver "^6.3.1"
+
+"@babel/preset-modules@0.1.6-no-external-plugins":
+  version "0.1.6-no-external-plugins"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz#ccb88a2c49c817236861fee7826080573b8a923a"
+  integrity sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
+"@babel/preset-react@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.27.1.tgz#86ea0a5ca3984663f744be2fd26cb6747c3fd0ec"
+  integrity sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-transform-react-display-name" "^7.27.1"
+    "@babel/plugin-transform-react-jsx" "^7.27.1"
+    "@babel/plugin-transform-react-jsx-development" "^7.27.1"
+    "@babel/plugin-transform-react-pure-annotations" "^7.27.1"
+
+"@babel/preset-typescript@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz#190742a6428d282306648a55b0529b561484f912"
+  integrity sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-transform-modules-commonjs" "^7.27.1"
+    "@babel/plugin-transform-typescript" "^7.27.1"
 
 "@babel/runtime-corejs3@^7.10.2":
   version "7.17.9"
@@ -323,7 +1061,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/template@^7.27.2", "@babel/template@^7.3.3":
+"@babel/template@^7.27.1", "@babel/template@^7.27.2", "@babel/template@^7.3.3":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
   integrity sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==
@@ -345,6 +1083,19 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.0.tgz#518aa113359b062042379e333db18380b537e34b"
+  integrity sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.28.0"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.28.0"
+    "@babel/template" "^7.27.2"
+    "@babel/types" "^7.28.0"
+    debug "^4.3.1"
+
 "@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.3.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.3.tgz#c0257bedf33aad6aad1f406d35c44758321eb3ec"
@@ -360,6 +1111,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.28.0", "@babel/types@^7.4.4":
+  version "7.28.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.1.tgz#2aaf3c10b31ba03a77ac84f52b3912a0edef4cf9"
+  integrity sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -704,6 +1463,14 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
+"@jridgewell/gen-mapping@^0.3.12":
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz#2234ce26c62889f03db3d7fea43c1932ab3e927b"
+  integrity sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
@@ -728,10 +1495,23 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
+"@jridgewell/sourcemap-codec@^1.5.0":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz#7358043433b2e5da569aa02cbc4c121da3af27d7"
+  integrity sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==
+
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.29"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz#a58d31eaadaf92c6695680b2e1d464a9b8fbf7fc"
+  integrity sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -2316,6 +3096,30 @@ babel-plugin-macros@^2.6.1:
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
+babel-plugin-polyfill-corejs2@^0.4.14:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz#8101b82b769c568835611542488d463395c2ef8f"
+  integrity sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==
+  dependencies:
+    "@babel/compat-data" "^7.27.7"
+    "@babel/helper-define-polyfill-provider" "^0.6.5"
+    semver "^6.3.1"
+
+babel-plugin-polyfill-corejs3@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz#bb7f6aeef7addff17f7602a08a6d19a128c30164"
+  integrity sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.6.5"
+    core-js-compat "^3.43.0"
+
+babel-plugin-polyfill-regenerator@^0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz#32752e38ab6f6767b92650347bf26a31b16ae8c5"
+  integrity sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.6.5"
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz#9a929eafece419612ef4ae4f60b1862ebad8ef30"
@@ -2425,6 +3229,16 @@ browserslist@^4.24.0:
   dependencies:
     caniuse-lite "^1.0.30001716"
     electron-to-chromium "^1.5.149"
+    node-releases "^2.0.19"
+    update-browserslist-db "^1.1.3"
+
+browserslist@^4.25.1:
+  version "4.25.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.25.1.tgz#ba9e8e6f298a1d86f829c9b975e07948967bb111"
+  integrity sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==
+  dependencies:
+    caniuse-lite "^1.0.30001726"
+    electron-to-chromium "^1.5.173"
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.3"
 
@@ -2569,6 +3383,11 @@ caniuse-lite@^1.0.30001716:
   version "1.0.30001718"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz#dae13a9c80d517c30c6197515a96131c194d8f82"
   integrity sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==
+
+caniuse-lite@^1.0.30001726:
+  version "1.0.30001727"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz#22e9706422ad37aa50556af8c10e40e2d93a8b85"
+  integrity sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==
 
 chalk@^1.1.1:
   version "1.1.3"
@@ -3015,6 +3834,13 @@ copyfiles@^2.4.1:
     untildify "^4.0.0"
     yargs "^16.1.0"
 
+core-js-compat@^3.43.0:
+  version "3.44.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.44.0.tgz#62b9165b97e4cbdb8bca16b14818e67428b4a0f8"
+  integrity sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==
+  dependencies:
+    browserslist "^4.25.1"
+
 core-js-pure@^3.20.2:
   version "3.22.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.22.5.tgz#bdee0ed2f9b78f2862cda4338a07b13a49b6c9a9"
@@ -3152,7 +3978,7 @@ debug@^4.2.0:
   dependencies:
     ms "2.1.2"
 
-debug@^4.3.1:
+debug@^4.3.1, debug@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -3415,6 +4241,11 @@ electron-to-chromium@^1.5.149:
   version "1.5.159"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz#b909c4a5dbd00674f18419199f71c945a199effe"
   integrity sha512-CEvHptWAMV5p6GJ0Lq8aheyvVbfzVrv5mmidu1D3pidoVNkB3tTBsTMVtPJ+rzRK5oV229mCLz9Zj/hNvU8GBA==
+
+electron-to-chromium@^1.5.173:
+  version "1.5.182"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz#4ab73104f893938acb3ab9c28d7bec170c116b3e"
+  integrity sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==
 
 elliptic@^6.5.7:
   version "6.6.1"
@@ -4957,6 +5788,13 @@ is-core-module@^2.1.0, is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-mod
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.16.0:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
+  integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
+  dependencies:
+    hasown "^2.0.2"
+
 is-date-object@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
@@ -5618,6 +6456,11 @@ jsesc@^3.0.2:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
+jsesc@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
+
 json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
@@ -6050,6 +6893,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.findkey@^4.6.0:
   version "4.6.0"
@@ -7550,6 +8398,18 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+regenerate-unicode-properties@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz#626e39df8c372338ea9b8028d1f99dc3fd9c3db0"
+  integrity sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==
+  dependencies:
+    regenerate "^1.4.2"
+
+regenerate@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
+  integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
 regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
@@ -7574,6 +8434,18 @@ regexpp@^3.0.0, regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+regexpu-core@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-6.2.0.tgz#0e5190d79e542bf294955dccabae04d3c7d53826"
+  integrity sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==
+  dependencies:
+    regenerate "^1.4.2"
+    regenerate-unicode-properties "^10.2.0"
+    regjsgen "^0.8.0"
+    regjsparser "^0.12.0"
+    unicode-match-property-ecmascript "^2.0.0"
+    unicode-match-property-value-ecmascript "^2.1.0"
+
 registry-auth-token@^4.0.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz#f02d49c3668884612ca031419491a13539e21fac"
@@ -7587,6 +8459,18 @@ registry-url@^5.0.0:
   integrity sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
   dependencies:
     rc "^1.2.8"
+
+regjsgen@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.8.0.tgz#df23ff26e0c5b300a6470cad160a9d090c3a37ab"
+  integrity sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==
+
+regjsparser@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.12.0.tgz#0e846df6c6530586429377de56e0475583b088dc"
+  integrity sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==
+  dependencies:
+    jsesc "~3.0.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -7646,6 +8530,15 @@ resolve@^1.12.0:
   dependencies:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
+
+resolve@^1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
+  integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
+  dependencies:
+    is-core-module "^2.16.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
@@ -8512,6 +9405,29 @@ unbox-primitive@^1.0.1, unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+unicode-canonical-property-names-ecmascript@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz#cb3173fe47ca743e228216e4a3ddc4c84d628cc2"
+  integrity sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==
+
+unicode-match-property-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz#54fd16e0ecb167cf04cf1f756bdcc92eba7976c3"
+  integrity sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==
+  dependencies:
+    unicode-canonical-property-names-ecmascript "^2.0.0"
+    unicode-property-aliases-ecmascript "^2.0.0"
+
+unicode-match-property-value-ecmascript@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz#a0401aee72714598f739b68b104e4fe3a0cb3c71"
+  integrity sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==
+
+unicode-property-aliases-ecmascript@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
+  integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
 unique-filename@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
- Add extensive test coverage for chain.ts with error handling scenarios
- Add complete test suite for graphql.ts including initialization and error cases
- Add thorough tests for serviceHeaderBuilder.ts with various input scenarios
- Refactor GraphQL initialization methods to use void return type instead of boolean
- Improve error messages and validation in chain.ts with detailed context
- Update babel configuration for better test environment support
- Add coverage directory to .gitignore
- Enhance example app with improved user interface for chain operations
- Update package.json dependencies and test configurations